### PR TITLE
Dev sse

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/verr/myapplication/data/TeamMember.kt
+++ b/app/src/main/java/com/verr/myapplication/data/TeamMember.kt
@@ -25,6 +25,14 @@ object TeamData {
         ),
         TeamMember(
             id = 2,
+            name = "심서은",
+            job = "FrontEnd Developer",
+            location = "Yangsan, Korea, PKNU",
+            description = "프론트 엔드와 앱 개발을 배우는 중입니다!",
+            profileImageUrl = "https://avatars.githubusercontent.com/u/202733674?v=4"
+        ),
+        TeamMember(
+            id = 3,
             name = "팀원을 추가해주세요",
             job = "... Developer",
             location = "Busan, Korea",

--- a/app/src/main/java/com/verr/myapplication/main/MainActivity.kt
+++ b/app/src/main/java/com/verr/myapplication/main/MainActivity.kt
@@ -25,9 +25,10 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun startMemberProfile(member: TeamMember) {
-        /**
-         * intent를 추가해주세요.
-         * **/
+        val intent=Intent(this, ProfileActivity::class.java).apply {
+            putExtra("team_member", member)
+            setExtrasClassLoader(TeamMember::class.java.classLoader)
+        }
         startActivity(intent)
     }
 }

--- a/app/src/main/java/com/verr/myapplication/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/verr/myapplication/profile/ProfileScreen.kt
@@ -1,5 +1,9 @@
 package com.verr.myapplication.profile
 
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -135,25 +139,37 @@ private fun ProfileContent(
                 .clip(RoundedCornerShape(75.dp)),
             elevation = CardDefaults.cardElevation(defaultElevation = 12.dp)
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        Brush.radialGradient(
-                            colors = listOf(
-                                Color(0xFF2196F3),
-                                Color(0xFF1976D2)
-                            )
-                        )
-                    ),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Person,
-                    contentDescription = "Profile",
-                    modifier = Modifier.size(80.dp),
-                    tint = Color.White
+            val ctx = LocalContext.current
+            val url = teamMember.profileImageUrl?.trim()
+
+            if (!url.isNullOrBlank() && (url.startsWith("http://") || url.startsWith("https://"))) {
+                AsyncImage(
+                    model = ImageRequest.Builder(ctx)
+                        .data(url)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = "Profile Picture",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
                 )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            Brush.radialGradient(
+                                colors = listOf(Color(0xFF2196F3), Color(0xFF1976D2))
+                            )
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Person,
+                        contentDescription = "Profile",
+                        modifier = Modifier.size(80.dp),
+                        tint = Color.White
+                    )
+                }
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.12.2"
+agp = "8.13.0"
 kotlin = "2.0.21"
 coreKtx = "1.17.0"
 junit = "4.13.2"


### PR DESCRIPTION
자기소개 데이터 추가 및 깃허브 프로필 url 추가.

팀원 목록에서 팀원을 선택하였을 경우 프로필로 이동이 안되지 않았음
->팀원을 선택하면 그 팀원의 정보를 담은 TeamMember 객체를 Intent에 넣어서
ProfileActivity로 전달하도록 코드를 수정함.

깃허브 프로필 이미지(외부 url)을 가져와 프로필 화면에 보여주기 위해 Coil라이브러리 관련 import를 추가함.

프로필에 들어갔을 때 url이 있으면 프로필 사진으로 없거나 실패하면 아이콘으로 띄우도록 변경함.
